### PR TITLE
#134 terminologie.pyリファクタリング Feature/#134

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -1,4 +1,4 @@
-from model import  app
+from model import app
 
 # # モジュールのインポート
 from main import main_module

--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -1,22 +1,17 @@
-from model import  app #, Person, db
-# from flask import request
+from model import  app
 
 # # モジュールのインポート
 from main import main_module
 from user import user_module
-from terminologie import terminologie_module, create_module, update_module, delete_module
+from terminologie import terminologie_module, edit_module
 from result import result_module
 from record import record_module
-
-# app = Flask(__name__)
 
 # コントローラー先
 app.register_blueprint(main_module)
 app.register_blueprint(user_module)
 app.register_blueprint(terminologie_module)
-app.register_blueprint(create_module)
-app.register_blueprint(update_module)
-app.register_blueprint(delete_module)
+app.register_blueprint(edit_module)
 app.register_blueprint(result_module)
 app.register_blueprint(record_module)
 

--- a/backend/app/model.py
+++ b/backend/app/model.py
@@ -40,7 +40,7 @@ db = SQLAlchemy(app)
 Migrate(app, db)
 
 # 以降各テーブル usersテーブルのクラス名はUserだとザックリしすぎなのでPersonとした
-class Person(UserMixin,db.Model):
+class Person(UserMixin, db.Model):
     
     __tablename__ = "users"
 

--- a/backend/app/terminologie.py
+++ b/backend/app/terminologie.py
@@ -3,10 +3,8 @@ from model import app, Terminologie, db
 
 app.config["JSON_AS_ASCII"] = False
 
-terminologie_module = Blueprint("terminologie_module", __name__, template_folder="templates", url_prefix="/terminologie")
-edit_module = Blueprint("create_module", __name__, template_folder="templates")
-# update_module = Blueprint("update_module", __name__, template_folder="templates")
-# delete_module = Blueprint("delete_module", __name__)
+terminologie_module = Blueprint("terminologie_module", __name__, url_prefix="/terminologie")
+edit_module = Blueprint("edit_module", __name__, template_folder="templates")
 
 # 用語全てをJSONで取得
 @terminologie_module.route("/", methods=["GET"])
@@ -57,7 +55,7 @@ def create():
         # 新規データなのでadd必要
         db.session.add(post)
         db.session.commit()
-        return redirect("/create")
+        return redirect("/")
     else:
         return render_template("create.html")
     

--- a/backend/app/terminologie.py
+++ b/backend/app/terminologie.py
@@ -3,13 +3,13 @@ from model import app, Terminologie, db
 
 app.config["JSON_AS_ASCII"] = False
 
-terminologie_module = Blueprint("terminologie_module", __name__)
-create_module = Blueprint("create_module", __name__, template_folder="templates")
-update_module = Blueprint("update_module", __name__, template_folder="templates")
-delete_module = Blueprint("delete_module", __name__)
+terminologie_module = Blueprint("terminologie_module", __name__, template_folder="templates", url_prefix="/terminologie")
+edit_module = Blueprint("create_module", __name__, template_folder="templates")
+# update_module = Blueprint("update_module", __name__, template_folder="templates")
+# delete_module = Blueprint("delete_module", __name__)
 
 # 用語全てをJSONで取得
-@terminologie_module.route("/terminologie/", methods=["GET"])
+@terminologie_module.route("/", methods=["GET"])
 def terms():
     terms = Terminologie.query.all()
     data = [
@@ -27,7 +27,7 @@ def terms():
     return jsonify(data) 
 
 # 用語を１つだけJSONで取得
-@terminologie_module.route("/terminologie/<int:terminologie_id>", methods=["GET"])
+@terminologie_module.route("/<int:terminologie_id>", methods=["GET"])
 def term(terminologie_id):
     term = Terminologie.query.get(terminologie_id)
     data = [
@@ -43,7 +43,7 @@ def term(terminologie_id):
     return jsonify(data) 
 
 # 用語の新規作成
-@create_module.route("/create", methods=["GET", "POST"])
+@edit_module.route("/create", methods=["GET", "POST"])
 def create():
     if request.method == "POST":
         genre_id = request.form.get("genre_id")
@@ -62,7 +62,7 @@ def create():
         return render_template("create.html")
     
 # 用語の編集
-@update_module.route("/update/<int:terminologie_id>", methods=["GET", "POST"])
+@edit_module.route("/update/<int:terminologie_id>", methods=["GET", "POST"])
 def update(terminologie_id):
     term = Terminologie.query.get(terminologie_id)
     if request.method == "GET":
@@ -78,7 +78,7 @@ def update(terminologie_id):
         return "用語の編集が完了しました"
 
 # 用語の削除（問答無用で削除されます）
-@delete_module.route("/delete/<int:terminologie_id>", methods=["GET", "POST"])
+@edit_module.route("/delete/<int:terminologie_id>", methods=["GET", "POST"])
 # @login_required
 def delete(terminologie_id):
     post = Terminologie.query.get(terminologie_id)


### PR DESCRIPTION
fix #134 
terminologie.pyの以下のエンドポイントをprefixとしました
http://localhost:5001/terminologie/
http://localhost:5001/terminologie/{terminologie_id}

以下のエンドポイントのモジュールをテンプレートを参照する`edit_module`としました
http://localhost:5001/create
http://localhost:5001/update/{terminologie_id}

http://localhost:5001/delete/{terminologie_id}

### 問題
テンプレートを参照するcreateとupdateにおいてサーバーエラー500が発生しました
エラーコードからFlask-loginがテンプレートディレクトリに対し影響してしまっているようです
Flask-loginをインストールした時点から制御下に置かれ接続不能となっていたと思われます

flask-loginを一旦コメントアウトすると表示されることで確定しました

### 解決策
* flask-loginを使用しないなら消す
　* この場合モジュールをterminologie_module一本化可能
　　* 影響はエンドポイントURLが変わることくらい
* flask-loginを使用するならフォームをpythonで書き直す

とりあえず現状は使わないことと、サンプル問題は差し込めるため別issueとし様子見ますｗ

使用していないとのことなので影響ない形でFlask-loginを取り除く方針です